### PR TITLE
chore: add env vars for those that do not have `uesio_` prefix

### DIFF
--- a/aws/dev/ecs/task_definitions/uesio_web.json
+++ b/aws/dev/ecs/task_definitions/uesio_web.json
@@ -32,6 +32,10 @@
           "value": "tcrtwqn3akb2b2r.eafgxk.ng.0001.use1.cache.amazonaws.com"
         },
         {
+          "name": "UESIO_REDIS_HOST",
+          "value": "tcrtwqn3akb2b2r.eafgxk.ng.0001.use1.cache.amazonaws.com"
+        },        
+        {
           "name": "UESIO_DB_PORT",
           "value": "5432"
         },
@@ -57,6 +61,10 @@
         },
         {
           "name": "REDIS_PORT",
+          "value": "6379"
+        },
+        {
+          "name": "UESIO_REDIS_PORT",
           "value": "6379"
         },
         {

--- a/aws/dev/ecs/task_definitions/uesio_worker.json
+++ b/aws/dev/ecs/task_definitions/uesio_worker.json
@@ -36,6 +36,10 @@
           "value": "tcrtwqn3akb2b2r.eafgxk.ng.0001.use1.cache.amazonaws.com"
         },
         {
+          "name": "UESIO_REDIS_HOST",
+          "value": "tcrtwqn3akb2b2r.eafgxk.ng.0001.use1.cache.amazonaws.com"
+        },        
+        {
           "name": "UESIO_DB_PORT",
           "value": "5432"
         },
@@ -61,6 +65,10 @@
         },
         {
           "name": "REDIS_PORT",
+          "value": "6379"
+        },
+        {
+          "name": "UESIO_REDIS_PORT",
           "value": "6379"
         },
         {

--- a/aws/prod/ecs/task_definitions/uesio_web.json
+++ b/aws/prod/ecs/task_definitions/uesio_web.json
@@ -32,6 +32,10 @@
           "value": "redis-cluster.ues.io"
         },
         {
+          "name": "UESIO_REDIS_HOST",
+          "value": "redis-cluster.ues.io"
+        },        
+        {
           "name": "UESIO_DB_PORT",
           "value": "5432"
         },
@@ -57,6 +61,10 @@
         },
         {
           "name": "REDIS_PORT",
+          "value": "6379"
+        },
+        {
+          "name": "UESIO_REDIS_PORT",
           "value": "6379"
         },
         {

--- a/aws/prod/ecs/task_definitions/uesio_worker.json
+++ b/aws/prod/ecs/task_definitions/uesio_worker.json
@@ -36,6 +36,10 @@
           "value": "redis-cluster.ues.io"
         },
         {
+          "name": "UESIO_REDIS_HOST",
+          "value": "redis-cluster.ues.io"
+        },        
+        {
           "name": "UESIO_DB_PORT",
           "value": "5432"
         },
@@ -61,6 +65,10 @@
         },
         {
           "name": "REDIS_PORT",
+          "value": "6379"
+        },
+        {
+          "name": "UESIO_REDIS_PORT",
           "value": "6379"
         },
         {


### PR DESCRIPTION
1. Adds new env vars to replace those that do not contain `UESIO_` prefix per changes in https://github.com/ues-io/uesio/pull/4765.
2. Adds new `UESIO_EXTERNAL_BUNDLE_STORE_BASE_URL` that replaces `UESIO_BUNDLE_STORE_DOMAIN`

This PR does not remove any env vars, only adds `UESIO_` versions for those that do not have that naming convention currently (only `REDIS_HOST` & `REDIS_PORT`).

A subsequent PR will remove the retired env vars once a "hot swap" of the image is completed.

@humandad  - Couple of q's:

1. There is an env variable [OPENAI_API_KEY](https://github.com/TheCloudMasters/uesio-infra/blob/main/aws/dev/ecs/task_definitions/uesio_web.json#L97) referenced in the definitions (dev & prod):
    1.  I do not see that this is used anywhere in the uesio code base - do you know where its used or if it can be removed from the definitions here?
    3. In the uesio repo docs, it mentions [UESIO_SECRET_UESIO_CORE_OPENAIKEY](https://github.com/ues-io/uesio/blob/main/docs/deployment/aws-ecs/taskdefinition-web-app.json#L61) but in this repo, it's `OPEN_API_KEY`.  If this is used, are the repo docs wrong?
4. There is an env variable [UESIO_SECRET_UESIO_CORE_SENDGRIDKEY](https://github.com/TheCloudMasters/uesio-infra/blob/main/aws/dev/ecs/task_definitions/uesio_web.json#L105) which also doesn't appear to be used anywhere.  Do you know where it is used or if it can be removed from the definition?