### PR TITLE
chore: add UESIO_EXTERNAL_BUNDLE_STORE_BASE_URL to replace UESIO_BUNDLE_STORE_DOMAIN

### DIFF
--- a/aws/dev/ecs/task_definitions/uesio_web.json
+++ b/aws/dev/ecs/task_definitions/uesio_web.json
@@ -20,6 +20,10 @@
           "value": "ues.io"
         },
         {
+          "name": "UESIO_EXTERNAL_BUNDLE_STORE_BASE_URL",
+          "value": "https://studio.ues.io"
+        },
+        {
           "name": "UESIO_PRIMARY_DOMAIN",
           "value": "ues-dev.io"
         },
@@ -34,7 +38,7 @@
         {
           "name": "UESIO_REDIS_HOST",
           "value": "tcrtwqn3akb2b2r.eafgxk.ng.0001.use1.cache.amazonaws.com"
-        },        
+        },
         {
           "name": "UESIO_DB_PORT",
           "value": "5432"
@@ -129,9 +133,7 @@
   "taskRoleArn": "arn:aws:iam::666606836305:role/tcm-uesio-dev-ecs-cluster-ECSTaskIamRole-1P5SL84CIJW4F",
   "executionRoleArn": "arn:aws:iam::666606836305:role/tcm-uesio-dev-ecs-cluster-ECSTaskExecutionRole-1SO1H7JFEWLJR",
   "networkMode": "awsvpc",
-  "requiresCompatibilities": [
-    "FARGATE"
-  ],
+  "requiresCompatibilities": ["FARGATE"],
   "cpu": "256",
   "memory": "512"
 }

--- a/aws/dev/ecs/task_definitions/uesio_worker.json
+++ b/aws/dev/ecs/task_definitions/uesio_worker.json
@@ -13,15 +13,16 @@
           "protocol": "tcp"
         }
       ],
-      "command": [
-        "./uesio",
-        "worker"
-      ],
+      "command": ["./uesio", "worker"],
       "essential": true,
       "environment": [
         {
           "name": "UESIO_BUNDLE_STORE_DOMAIN",
           "value": "ues.io"
+        },
+        {
+          "name": "UESIO_EXTERNAL_BUNDLE_STORE_BASE_URL",
+          "value": "https://studio.ues.io"
         },
         {
           "name": "UESIO_PRIMARY_DOMAIN",
@@ -38,7 +39,7 @@
         {
           "name": "UESIO_REDIS_HOST",
           "value": "tcrtwqn3akb2b2r.eafgxk.ng.0001.use1.cache.amazonaws.com"
-        },        
+        },
         {
           "name": "UESIO_DB_PORT",
           "value": "5432"
@@ -117,9 +118,7 @@
   "taskRoleArn": "arn:aws:iam::666606836305:role/tcm-uesio-dev-ecs-cluster-ECSTaskIamRole-1P5SL84CIJW4F",
   "executionRoleArn": "arn:aws:iam::666606836305:role/tcm-uesio-dev-ecs-cluster-ECSTaskExecutionRole-1SO1H7JFEWLJR",
   "networkMode": "awsvpc",
-  "requiresCompatibilities": [
-    "FARGATE"
-  ],
+  "requiresCompatibilities": ["FARGATE"],
   "cpu": "256",
   "memory": "512"
 }

--- a/aws/prod/ecs/task_definitions/uesio_web.json
+++ b/aws/prod/ecs/task_definitions/uesio_web.json
@@ -20,6 +20,10 @@
           "value": "ues.io"
         },
         {
+          "name": "UESIO_EXTERNAL_BUNDLE_STORE_BASE_URL",
+          "value": "https://studio.ues.io"
+        },
+        {
           "name": "UESIO_PRIMARY_DOMAIN",
           "value": "ues.io"
         },
@@ -34,7 +38,7 @@
         {
           "name": "UESIO_REDIS_HOST",
           "value": "redis-cluster.ues.io"
-        },        
+        },
         {
           "name": "UESIO_DB_PORT",
           "value": "5432"
@@ -129,15 +133,10 @@
   "taskRoleArn": "arn:aws:iam::460657680679:role/tcm-uesio-prod-ecs-cluster-ECSTaskIamRole-1GBUSORAI4Z1C",
   "executionRoleArn": "arn:aws:iam::460657680679:role/tcm-uesio-prod-ecs-cluster-ECSTaskExecutionRole-1OVO34GCW60TV",
   "networkMode": "awsvpc",
-  "requiresCompatibilities": [
-    "FARGATE"
-  ],
+  "requiresCompatibilities": ["FARGATE"],
   "cpu": "512",
   "memory": "1024",
   "placementConstraints": [],
-  "compatibilities": [
-    "EC2",
-    "FARGATE"
-  ],
+  "compatibilities": ["EC2", "FARGATE"],
   "tags": []
 }

--- a/aws/prod/ecs/task_definitions/uesio_worker.json
+++ b/aws/prod/ecs/task_definitions/uesio_worker.json
@@ -13,15 +13,16 @@
           "protocol": "tcp"
         }
       ],
-      "command": [
-        "./uesio",
-        "worker"
-      ],
+      "command": ["./uesio", "worker"],
       "essential": true,
       "environment": [
         {
           "name": "UESIO_BUNDLE_STORE_DOMAIN",
           "value": "ues.io"
+        },
+        {
+          "name": "UESIO_EXTERNAL_BUNDLE_STORE_BASE_URL",
+          "value": "https://studio.ues.io"
         },
         {
           "name": "UESIO_PRIMARY_DOMAIN",
@@ -38,7 +39,7 @@
         {
           "name": "UESIO_REDIS_HOST",
           "value": "redis-cluster.ues.io"
-        },        
+        },
         {
           "name": "UESIO_DB_PORT",
           "value": "5432"
@@ -117,15 +118,10 @@
   "taskRoleArn": "arn:aws:iam::460657680679:role/tcm-uesio-prod-ecs-cluster-ECSTaskIamRole-1GBUSORAI4Z1C",
   "executionRoleArn": "arn:aws:iam::460657680679:role/tcm-uesio-prod-ecs-cluster-ECSTaskExecutionRole-1OVO34GCW60TV",
   "networkMode": "awsvpc",
-  "requiresCompatibilities": [
-    "FARGATE"
-  ],
+  "requiresCompatibilities": ["FARGATE"],
   "cpu": "512",
   "memory": "1024",
   "placementConstraints": [],
-  "compatibilities": [
-    "EC2",
-    "FARGATE"
-  ],
+  "compatibilities": ["EC2", "FARGATE"],
   "tags": []
 }


### PR DESCRIPTION
Adds `UESIO_EXTERNAL_BUNDLE_STORE_BASE_URL` to env config which will replace UESIO_BUNDLE_STORE_DOMAIN per https://github.com/ues-io/uesio/pull/4767.

This PR adds the new value and leaves the old to enable hot swap.

Once https://github.com/ues-io/uesio/pull/4767 is merged and deployed to dev & prod, UESIO_BUNDLE_STORE_DOMAIN can be removed.