### PR TITLE
chore: remove unused env vars and those that have same value for platform default

### DIFF
--- a/aws/dev/ecs/task_definitions/uesio_web.json
+++ b/aws/dev/ecs/task_definitions/uesio_web.json
@@ -44,10 +44,6 @@
           "value": "uesio.s3"
         },
         {
-          "name": "UESIO_REDIS_PORT",
-          "value": "6379"
-        },
-        {
           "name": "UESIO_PLATFORM_BUNDLESTORE_CREDENTIALS",
           "value": "uesio/core.aws"
         },
@@ -97,9 +93,7 @@
   "taskRoleArn": "arn:aws:iam::666606836305:role/tcm-uesio-dev-ecs-cluster-ECSTaskIamRole-1P5SL84CIJW4F",
   "executionRoleArn": "arn:aws:iam::666606836305:role/tcm-uesio-dev-ecs-cluster-ECSTaskExecutionRole-1SO1H7JFEWLJR",
   "networkMode": "awsvpc",
-  "requiresCompatibilities": [
-    "FARGATE"
-  ],
+  "requiresCompatibilities": ["FARGATE"],
   "cpu": "256",
   "memory": "512"
 }

--- a/aws/dev/ecs/task_definitions/uesio_web.json
+++ b/aws/dev/ecs/task_definitions/uesio_web.json
@@ -16,14 +16,6 @@
       "essential": true,
       "environment": [
         {
-          "name": "UESIO_BUNDLE_STORE_DOMAIN",
-          "value": "ues.io"
-        },
-        {
-          "name": "UESIO_EXTERNAL_BUNDLE_STORE_BASE_URL",
-          "value": "https://studio.ues.io"
-        },
-        {
           "name": "UESIO_PRIMARY_DOMAIN",
           "value": "ues-dev.io"
         },
@@ -32,16 +24,8 @@
           "value": "uesiobundlestore-dev"
         },
         {
-          "name": "REDIS_HOST",
-          "value": "tcrtwqn3akb2b2r.eafgxk.ng.0001.use1.cache.amazonaws.com"
-        },
-        {
           "name": "UESIO_REDIS_HOST",
           "value": "tcrtwqn3akb2b2r.eafgxk.ng.0001.use1.cache.amazonaws.com"
-        },
-        {
-          "name": "UESIO_DB_PORT",
-          "value": "5432"
         },
         {
           "name": "UESIO_SESSION_STORE",
@@ -56,16 +40,8 @@
           "value": "postgresio"
         },
         {
-          "name": "UESIO_CACHE_SITE_BUNDLES",
-          "value": "true"
-        },
-        {
           "name": "UESIO_PLATFORM_BUNDLESTORE_TYPE",
           "value": "uesio.s3"
-        },
-        {
-          "name": "REDIS_PORT",
-          "value": "6379"
         },
         {
           "name": "UESIO_REDIS_PORT",
@@ -84,10 +60,6 @@
           "value": "uesiofiles-dev"
         },
         {
-          "name": "UESIO_PLATFORM_DATASOURCE_CREDENTIALS",
-          "value": "uesio/core.db"
-        },
-        {
           "name": "UESIO_PLATFORM_FILESOURCE_TYPE",
           "value": "uesio.s3"
         },
@@ -104,14 +76,6 @@
         {
           "name": "UESIO_DB_PASSWORD",
           "valueFrom": "arn:aws:secretsmanager:us-east-1:666606836305:secret:/rds/aurora/tcm-uesio-dev-aurora-1xtDNl:password::"
-        },
-        {
-          "name": "OPENAI_API_KEY",
-          "valueFrom": "arn:aws:secretsmanager:us-east-1:666606836305:secret:uesio-web/env/secrets-4Zg9nY:openai_api_key::"
-        },
-        {
-          "name": "UESIO_SECRET_UESIO_CORE_SENDGRIDKEY",
-          "valueFrom": "arn:aws:secretsmanager:us-east-1:666606836305:secret:uesio-web/env/secrets-4Zg9nY:sendgrid_api_key::"
         },
         {
           "name": "UESIO_SECRET_UESIO_APPKIT_RESEND_KEY",

--- a/aws/dev/ecs/task_definitions/uesio_worker.json
+++ b/aws/dev/ecs/task_definitions/uesio_worker.json
@@ -20,14 +20,6 @@
       "essential": true,
       "environment": [
         {
-          "name": "UESIO_BUNDLE_STORE_DOMAIN",
-          "value": "ues.io"
-        },
-        {
-          "name": "UESIO_EXTERNAL_BUNDLE_STORE_BASE_URL",
-          "value": "https://studio.ues.io"
-        },
-        {
           "name": "UESIO_PRIMARY_DOMAIN",
           "value": "ues-dev.io"
         },
@@ -36,16 +28,8 @@
           "value": "uesiobundlestore-dev"
         },
         {
-          "name": "REDIS_HOST",
-          "value": "tcrtwqn3akb2b2r.eafgxk.ng.0001.use1.cache.amazonaws.com"
-        },
-        {
           "name": "UESIO_REDIS_HOST",
           "value": "tcrtwqn3akb2b2r.eafgxk.ng.0001.use1.cache.amazonaws.com"
-        },
-        {
-          "name": "UESIO_DB_PORT",
-          "value": "5432"
         },
         {
           "name": "UESIO_SESSION_STORE",
@@ -60,16 +44,8 @@
           "value": "postgresio"
         },
         {
-          "name": "UESIO_CACHE_SITE_BUNDLES",
-          "value": "true"
-        },
-        {
           "name": "UESIO_PLATFORM_BUNDLESTORE_TYPE",
           "value": "uesio.s3"
-        },
-        {
-          "name": "REDIS_PORT",
-          "value": "6379"
         },
         {
           "name": "UESIO_REDIS_PORT",
@@ -86,10 +62,6 @@
         {
           "name": "UESIO_USERFILES_BUCKET_NAME",
           "value": "uesiofiles-dev"
-        },
-        {
-          "name": "UESIO_PLATFORM_DATASOURCE_CREDENTIALS",
-          "value": "uesio/core.db"
         },
         {
           "name": "UESIO_PLATFORM_FILESOURCE_TYPE",

--- a/aws/dev/ecs/task_definitions/uesio_worker.json
+++ b/aws/dev/ecs/task_definitions/uesio_worker.json
@@ -13,10 +13,7 @@
           "protocol": "tcp"
         }
       ],
-      "command": [
-        "./uesio",
-        "worker"
-      ],
+      "command": ["./uesio", "worker"],
       "essential": true,
       "environment": [
         {
@@ -46,10 +43,6 @@
         {
           "name": "UESIO_PLATFORM_BUNDLESTORE_TYPE",
           "value": "uesio.s3"
-        },
-        {
-          "name": "UESIO_REDIS_PORT",
-          "value": "6379"
         },
         {
           "name": "UESIO_PLATFORM_BUNDLESTORE_CREDENTIALS",
@@ -93,9 +86,7 @@
   "taskRoleArn": "arn:aws:iam::666606836305:role/tcm-uesio-dev-ecs-cluster-ECSTaskIamRole-1P5SL84CIJW4F",
   "executionRoleArn": "arn:aws:iam::666606836305:role/tcm-uesio-dev-ecs-cluster-ECSTaskExecutionRole-1SO1H7JFEWLJR",
   "networkMode": "awsvpc",
-  "requiresCompatibilities": [
-    "FARGATE"
-  ],
+  "requiresCompatibilities": ["FARGATE"],
   "cpu": "256",
   "memory": "512"
 }

--- a/aws/prod/ecs/task_definitions/uesio_web.json
+++ b/aws/prod/ecs/task_definitions/uesio_web.json
@@ -44,10 +44,6 @@
           "value": "uesio.s3"
         },
         {
-          "name": "UESIO_REDIS_PORT",
-          "value": "6379"
-        },
-        {
           "name": "UESIO_PLATFORM_BUNDLESTORE_CREDENTIALS",
           "value": "uesio/core.aws"
         },

--- a/aws/prod/ecs/task_definitions/uesio_web.json
+++ b/aws/prod/ecs/task_definitions/uesio_web.json
@@ -16,14 +16,6 @@
       "essential": true,
       "environment": [
         {
-          "name": "UESIO_BUNDLE_STORE_DOMAIN",
-          "value": "ues.io"
-        },
-        {
-          "name": "UESIO_EXTERNAL_BUNDLE_STORE_BASE_URL",
-          "value": "https://studio.ues.io"
-        },
-        {
           "name": "UESIO_PRIMARY_DOMAIN",
           "value": "ues.io"
         },
@@ -32,16 +24,8 @@
           "value": "tcm-uesiobundlestore-prod"
         },
         {
-          "name": "REDIS_HOST",
-          "value": "redis-cluster.ues.io"
-        },
-        {
           "name": "UESIO_REDIS_HOST",
           "value": "redis-cluster.ues.io"
-        },
-        {
-          "name": "UESIO_DB_PORT",
-          "value": "5432"
         },
         {
           "name": "UESIO_SESSION_STORE",
@@ -56,16 +40,8 @@
           "value": "postgresio"
         },
         {
-          "name": "UESIO_CACHE_SITE_BUNDLES",
-          "value": "true"
-        },
-        {
           "name": "UESIO_PLATFORM_BUNDLESTORE_TYPE",
           "value": "uesio.s3"
-        },
-        {
-          "name": "REDIS_PORT",
-          "value": "6379"
         },
         {
           "name": "UESIO_REDIS_PORT",
@@ -84,10 +60,6 @@
           "value": "tcm-uesiofiles-prod"
         },
         {
-          "name": "UESIO_PLATFORM_DATASOURCE_CREDENTIALS",
-          "value": "uesio/core.db"
-        },
-        {
           "name": "UESIO_PLATFORM_FILESOURCE_TYPE",
           "value": "uesio.s3"
         },
@@ -104,14 +76,6 @@
         {
           "name": "UESIO_DB_PASSWORD",
           "valueFrom": "arn:aws:secretsmanager:us-east-1:460657680679:secret:/rds/aurora/tcm-uesio-prod-rds-aurora-2pfXhW:password::"
-        },
-        {
-          "name": "OPENAI_API_KEY",
-          "valueFrom": "arn:aws:secretsmanager:us-east-1:460657680679:secret:/uesio-web/env/secrets-rJBtdy:openai_api_key::"
-        },
-        {
-          "name": "UESIO_SECRET_UESIO_CORE_SENDGRIDKEY",
-          "valueFrom": "arn:aws:secretsmanager:us-east-1:460657680679:secret:/uesio-web/env/secrets-rJBtdy:sendgrid_api_key::"
         },
         {
           "name": "UESIO_SECRET_UESIO_APPKIT_RESEND_KEY",

--- a/aws/prod/ecs/task_definitions/uesio_worker.json
+++ b/aws/prod/ecs/task_definitions/uesio_worker.json
@@ -45,10 +45,6 @@
           "value": "uesio.s3"
         },
         {
-          "name": "UESIO_REDIS_PORT",
-          "value": "6379"
-        },
-        {
           "name": "UESIO_PLATFORM_BUNDLESTORE_CREDENTIALS",
           "value": "uesio/core.aws"
         },

--- a/aws/prod/ecs/task_definitions/uesio_worker.json
+++ b/aws/prod/ecs/task_definitions/uesio_worker.json
@@ -17,14 +17,6 @@
       "essential": true,
       "environment": [
         {
-          "name": "UESIO_BUNDLE_STORE_DOMAIN",
-          "value": "ues.io"
-        },
-        {
-          "name": "UESIO_EXTERNAL_BUNDLE_STORE_BASE_URL",
-          "value": "https://studio.ues.io"
-        },
-        {
           "name": "UESIO_PRIMARY_DOMAIN",
           "value": "ues.io"
         },
@@ -33,16 +25,8 @@
           "value": "tcm-uesiobundlestore-prod"
         },
         {
-          "name": "REDIS_HOST",
-          "value": "redis-cluster.ues.io"
-        },
-        {
           "name": "UESIO_REDIS_HOST",
           "value": "redis-cluster.ues.io"
-        },
-        {
-          "name": "UESIO_DB_PORT",
-          "value": "5432"
         },
         {
           "name": "UESIO_SESSION_STORE",
@@ -57,16 +41,8 @@
           "value": "postgresio"
         },
         {
-          "name": "UESIO_CACHE_SITE_BUNDLES",
-          "value": "true"
-        },
-        {
           "name": "UESIO_PLATFORM_BUNDLESTORE_TYPE",
           "value": "uesio.s3"
-        },
-        {
-          "name": "REDIS_PORT",
-          "value": "6379"
         },
         {
           "name": "UESIO_REDIS_PORT",
@@ -83,10 +59,6 @@
         {
           "name": "UESIO_USERFILES_BUCKET_NAME",
           "value": "tcm-uesiofiles-prod"
-        },
-        {
-          "name": "UESIO_PLATFORM_DATASOURCE_CREDENTIALS",
-          "value": "uesio/core.db"
         },
         {
           "name": "UESIO_PLATFORM_FILESOURCE_TYPE",


### PR DESCRIPTION
1. Removes env vars that were replaced with new names. See:
    - #6 
    - #7
3. Removes all env vars whose value was set to be the same value that the platform sets as its corresponding default.  For example, `UESIO_DB_PORT` was removed because the platform defaults the value to 5432 so there isn't a need to have it defined in task defs.

@humandad  - Beyond general review, I could not find [UESIO_PLATFORM_DATASOURCE_CREDENTIALS](https://github.com/TheCloudMasters/uesio-infra/pull/9/files#diff-46e1cab38ae11cf933cabda58afa5310081083ed0b904042b119bb294fb137eeL87) used anywhere in the code so I removed it.  I'm assuming this was legacy but please confirm.