### PR TITLE
chore: override new platform defaults

### DIFF
--- a/aws/dev/ecs/task_definitions/uesio_web.json
+++ b/aws/dev/ecs/task_definitions/uesio_web.json
@@ -20,15 +20,19 @@
           "value": "ues-dev.io"
         },
         {
-          "name": "UESIO_BUNDLES_BUCKET_NAME",
-          "value": "uesiobundlestore-dev"
-        },
-        {
           "name": "UESIO_REDIS_HOST",
           "value": "tcrtwqn3akb2b2r.eafgxk.ng.0001.use1.cache.amazonaws.com"
         },
         {
           "name": "UESIO_SESSION_STORE",
+          "value": "redis"
+        },
+        {
+          "name": "UESIO_PLATFORM_CACHE",
+          "value": "redis"
+        },
+        {
+          "name": "UESIO_USAGE_HANDLER",
           "value": "redis"
         },
         {
@@ -40,6 +44,10 @@
           "value": "postgresio"
         },
         {
+          "name": "UESIO_DB_HOST",
+          "value": "write.ues-dev.io"
+        },
+        {
           "name": "UESIO_PLATFORM_BUNDLESTORE_TYPE",
           "value": "uesio.s3"
         },
@@ -48,20 +56,20 @@
           "value": "uesio/core.aws"
         },
         {
-          "name": "UESIO_PLATFORM_FILESOURCE_CREDENTIALS",
-          "value": "uesio/core.aws"
-        },
-        {
-          "name": "UESIO_USERFILES_BUCKET_NAME",
-          "value": "uesiofiles-dev"
+          "name": "UESIO_BUNDLES_BUCKET_NAME",
+          "value": "uesiobundlestore-dev"
         },
         {
           "name": "UESIO_PLATFORM_FILESOURCE_TYPE",
           "value": "uesio.s3"
         },
         {
-          "name": "UESIO_DB_HOST",
-          "value": "write.ues-dev.io"
+          "name": "UESIO_PLATFORM_FILESOURCE_CREDENTIALS",
+          "value": "uesio/core.aws"
+        },
+        {
+          "name": "UESIO_USERFILES_BUCKET_NAME",
+          "value": "uesiofiles-dev"
         },
         {
           "name": "UESIO_STATIC_ASSETS_HOST",

--- a/aws/dev/ecs/task_definitions/uesio_worker.json
+++ b/aws/dev/ecs/task_definitions/uesio_worker.json
@@ -21,15 +21,19 @@
           "value": "ues-dev.io"
         },
         {
-          "name": "UESIO_BUNDLES_BUCKET_NAME",
-          "value": "uesiobundlestore-dev"
-        },
-        {
           "name": "UESIO_REDIS_HOST",
           "value": "tcrtwqn3akb2b2r.eafgxk.ng.0001.use1.cache.amazonaws.com"
         },
         {
           "name": "UESIO_SESSION_STORE",
+          "value": "redis"
+        },
+        {
+          "name": "UESIO_PLATFORM_CACHE",
+          "value": "redis"
+        },
+        {
+          "name": "UESIO_USAGE_HANDLER",
           "value": "redis"
         },
         {
@@ -41,6 +45,10 @@
           "value": "postgresio"
         },
         {
+          "name": "UESIO_DB_HOST",
+          "value": "write.ues-dev.io"
+        },
+        {
           "name": "UESIO_PLATFORM_BUNDLESTORE_TYPE",
           "value": "uesio.s3"
         },
@@ -49,20 +57,20 @@
           "value": "uesio/core.aws"
         },
         {
-          "name": "UESIO_PLATFORM_FILESOURCE_CREDENTIALS",
-          "value": "uesio/core.aws"
-        },
-        {
-          "name": "UESIO_USERFILES_BUCKET_NAME",
-          "value": "uesiofiles-dev"
+          "name": "UESIO_BUNDLES_BUCKET_NAME",
+          "value": "uesiobundlestore-dev"
         },
         {
           "name": "UESIO_PLATFORM_FILESOURCE_TYPE",
           "value": "uesio.s3"
         },
         {
-          "name": "UESIO_DB_HOST",
-          "value": "write.ues-dev.io"
+          "name": "UESIO_PLATFORM_FILESOURCE_CREDENTIALS",
+          "value": "uesio/core.aws"
+        },
+        {
+          "name": "UESIO_USERFILES_BUCKET_NAME",
+          "value": "uesiofiles-dev"
         }
       ],
       "secrets": [

--- a/aws/prod/ecs/task_definitions/uesio_web.json
+++ b/aws/prod/ecs/task_definitions/uesio_web.json
@@ -20,15 +20,19 @@
           "value": "ues.io"
         },
         {
-          "name": "UESIO_BUNDLES_BUCKET_NAME",
-          "value": "tcm-uesiobundlestore-prod"
-        },
-        {
           "name": "UESIO_REDIS_HOST",
           "value": "redis-cluster.ues.io"
         },
         {
           "name": "UESIO_SESSION_STORE",
+          "value": "redis"
+        },
+        {
+          "name": "UESIO_PLATFORM_CACHE",
+          "value": "redis"
+        },
+        {
+          "name": "UESIO_USAGE_HANDLER",
           "value": "redis"
         },
         {
@@ -40,6 +44,10 @@
           "value": "postgresio"
         },
         {
+          "name": "UESIO_DB_HOST",
+          "value": "write.ues.io"
+        },
+        {
           "name": "UESIO_PLATFORM_BUNDLESTORE_TYPE",
           "value": "uesio.s3"
         },
@@ -48,20 +56,20 @@
           "value": "uesio/core.aws"
         },
         {
-          "name": "UESIO_PLATFORM_FILESOURCE_CREDENTIALS",
-          "value": "uesio/core.aws"
-        },
-        {
-          "name": "UESIO_USERFILES_BUCKET_NAME",
-          "value": "tcm-uesiofiles-prod"
+          "name": "UESIO_BUNDLES_BUCKET_NAME",
+          "value": "tcm-uesiobundlestore-prod"
         },
         {
           "name": "UESIO_PLATFORM_FILESOURCE_TYPE",
           "value": "uesio.s3"
         },
         {
-          "name": "UESIO_DB_HOST",
-          "value": "write.ues.io"
+          "name": "UESIO_PLATFORM_FILESOURCE_CREDENTIALS",
+          "value": "uesio/core.aws"
+        },
+        {
+          "name": "UESIO_USERFILES_BUCKET_NAME",
+          "value": "tcm-uesiofiles-prod"
         },
         {
           "name": "UESIO_STATIC_ASSETS_HOST",

--- a/aws/prod/ecs/task_definitions/uesio_worker.json
+++ b/aws/prod/ecs/task_definitions/uesio_worker.json
@@ -24,15 +24,19 @@
           "value": "ues.io"
         },
         {
-          "name": "UESIO_BUNDLES_BUCKET_NAME",
-          "value": "tcm-uesiobundlestore-prod"
-        },
-        {
           "name": "UESIO_REDIS_HOST",
           "value": "redis-cluster.ues.io"
         },
         {
           "name": "UESIO_SESSION_STORE",
+          "value": "redis"
+        },
+        {
+          "name": "UESIO_PLATFORM_CACHE",
+          "value": "redis"
+        },
+        {
+          "name": "UESIO_USAGE_HANDLER",
           "value": "redis"
         },
         {
@@ -44,6 +48,10 @@
           "value": "postgresio"
         },
         {
+          "name": "UESIO_DB_HOST",
+          "value": "write.ues.io"
+        },
+        {
           "name": "UESIO_PLATFORM_BUNDLESTORE_TYPE",
           "value": "uesio.s3"
         },
@@ -52,20 +60,20 @@
           "value": "uesio/core.aws"
         },
         {
-          "name": "UESIO_PLATFORM_FILESOURCE_CREDENTIALS",
-          "value": "uesio/core.aws"
-        },
-        {
-          "name": "UESIO_USERFILES_BUCKET_NAME",
-          "value": "tcm-uesiofiles-prod"
+          "name": "UESIO_BUNDLES_BUCKET_NAME",
+          "value": "tcm-uesiobundlestore-prod"
         },
         {
           "name": "UESIO_PLATFORM_FILESOURCE_TYPE",
           "value": "uesio.s3"
         },
         {
-          "name": "UESIO_DB_HOST",
-          "value": "write.ues.io"
+          "name": "UESIO_PLATFORM_FILESOURCE_CREDENTIALS",
+          "value": "uesio/core.aws"
+        },
+        {
+          "name": "UESIO_USERFILES_BUCKET_NAME",
+          "value": "tcm-uesiofiles-prod"
         }
       ],
       "secrets": [


### PR DESCRIPTION
Per https://github.com/ues-io/uesio/pull/4773, platform defaults are changing to target a localhost environment by default.

This PR:

1. Adds env vars to ensure that we explicitly override the new defaults to target the aws environment
2. Rearranges some of the env vars to logically group them