### PR TITLE
chore: update db sslmode to require in dev

### DIFF
--- a/aws/dev/ecs/task_definitions/uesio_web.json
+++ b/aws/dev/ecs/task_definitions/uesio_web.json
@@ -48,6 +48,10 @@
           "value": "write.ues-dev.io"
         },
         {
+          "name": "UESIO_DB_SSLMODE",
+          "value": "require"
+        },
+        {
           "name": "UESIO_PLATFORM_BUNDLESTORE_TYPE",
           "value": "uesio.s3"
         },

--- a/aws/dev/ecs/task_definitions/uesio_worker.json
+++ b/aws/dev/ecs/task_definitions/uesio_worker.json
@@ -52,6 +52,10 @@
           "value": "write.ues-dev.io"
         },
         {
+          "name": "UESIO_DB_SSLMODE",
+          "value": "require"
+        },
+        {
           "name": "UESIO_PLATFORM_BUNDLESTORE_TYPE",
           "value": "uesio.s3"
         },


### PR DESCRIPTION
Updated dev db to PG 17 in AWS

Update task definition to use `require` for ssl in dev task definitions.