### PR TITLE
chore: checkout from triggered branch

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -34,9 +34,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: main
-          fetch-depth: 1
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
Changes the behavior of deploy_aws workflow to checkout from the triggered branch instead of hardcoded to always be main.

This supports being able to run deploys from branches other than main while ensuring backwards compat for the auto deploys that are triggered from main directly.