### PR TITLE
chore: add healthcheck to prod task defs

### DIFF
--- a/aws/prod/ecs/task_definitions/uesio_web.json
+++ b/aws/prod/ecs/task_definitions/uesio_web.json
@@ -90,6 +90,16 @@
           "valueFrom": "arn:aws:secretsmanager:us-east-1:460657680679:secret:/uesio-web/env/secrets-rJBtdy:resend_api_key::"
         }
       ],
+      "healthCheck": {
+        "command": [
+          "CMD-SHELL",
+          "wget -q --no-check-certificate --spider http://localhost:3000/health || exit 1"
+        ],
+        "interval": 5,
+        "timeout": 5,
+        "retries": 10,
+        "startPeriod": 60
+      },      
       "mountPoints": [],
       "volumesFrom": [],
       "logConfiguration": {

--- a/aws/prod/ecs/task_definitions/uesio_worker.json
+++ b/aws/prod/ecs/task_definitions/uesio_worker.json
@@ -86,6 +86,16 @@
           "valueFrom": "arn:aws:secretsmanager:us-east-1:460657680679:secret:/rds/aurora/tcm-uesio-prod-rds-aurora-2pfXhW:password::"
         }
       ],
+      "healthCheck": {
+        "command": [
+          "CMD-SHELL",
+          "test -f /tmp/worker-healthcheck.json && test $(( $(date +%s) - $(stat -c %Y /tmp/worker-healthcheck.json) )) -lt 60"
+        ],
+        "interval": 5,
+        "timeout": 5,
+        "retries": 10,
+        "startPeriod": 60
+      },      
       "mountPoints": [],
       "volumesFrom": [],
       "logConfiguration": {


### PR DESCRIPTION
Adds healthchecks to prod task definitions.

NOTE: This cannot be merged/deployed yet since the prod images do not have the worker healthcheck support yet.  After the next release to prod, this PR should be merged with main (to pickup the latest image) and then can be merged which will trigger an automatic deployment that will include the healtchecks.