### PR TITLE
chore: fix prod taskdef warning & synchronize dev/prod task defs

### DIFF
--- a/aws/dev/ecs/task_definitions/uesio_web.json
+++ b/aws/dev/ecs/task_definitions/uesio_web.json
@@ -119,5 +119,7 @@
     "FARGATE"
   ],
   "cpu": "256",
-  "memory": "512"
+  "memory": "512",
+  "placementConstraints": [],
+  "tags": []
 }

--- a/aws/dev/ecs/task_definitions/uesio_worker.json
+++ b/aws/dev/ecs/task_definitions/uesio_worker.json
@@ -115,5 +115,7 @@
     "FARGATE"
   ],
   "cpu": "256",
-  "memory": "512"
+  "memory": "512",
+  "placementConstraints": [],
+  "tags": []
 }

--- a/aws/prod/ecs/task_definitions/uesio_web.json
+++ b/aws/prod/ecs/task_definitions/uesio_web.json
@@ -99,7 +99,7 @@
         "timeout": 5,
         "retries": 10,
         "startPeriod": 60
-      },      
+      },
       "mountPoints": [],
       "volumesFrom": [],
       "logConfiguration": {
@@ -121,9 +121,5 @@
   "cpu": "512",
   "memory": "1024",
   "placementConstraints": [],
-  "compatibilities": [
-    "EC2",
-    "FARGATE"
-  ],
   "tags": []
 }

--- a/aws/prod/ecs/task_definitions/uesio_worker.json
+++ b/aws/prod/ecs/task_definitions/uesio_worker.json
@@ -95,7 +95,7 @@
         "timeout": 5,
         "retries": 10,
         "startPeriod": 60
-      },      
+      },
       "mountPoints": [],
       "volumesFrom": [],
       "logConfiguration": {
@@ -117,9 +117,5 @@
   "cpu": "512",
   "memory": "1024",
   "placementConstraints": [],
-  "compatibilities": [
-    "EC2",
-    "FARGATE"
-  ],
   "tags": []
 }


### PR DESCRIPTION
1. Fixes the `Ignoring property 'compatibilities' in the task definition file....` warning in prod task definitions by removing the property
2. Synchronizes the task defs between dev/prod so they are 100% identical other than the property values based on the environment being targeted.