### PR TITLE
Chore/fix update environment image

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -6,6 +6,14 @@ on:
       environment:
         type: string
         required: true
+      target_ref:
+        # The branch, tag or SHA to checkout. When checking out the repository that
+        # triggered a workflow, this defaults to the reference or SHA for that event.
+        # Otherwise, uses the default branch. This should normally be left blank when
+        # this workflow is called from another workflow that was triggered by a 
+        # workflow_dispatch event.
+        description: 'The ref (branch, tag, or SHA) to use. Defaults to ref that triggered the workflow.'
+        type: string        
     secrets:
       AWS_ECS_ROLE_ARN:
         required: true
@@ -34,6 +42,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # When called by update-environment_image, this will have the value of the commit that was added
+          # in that workflow. In other scenarios, this should almost always be blank so that it uses the SHA
+          # from the even that triggered the workflow which called this workflow (e.g., a workflow_dispatch
+          # event that doesn't involve a commit in a prior step).
+          ref: ${{ inputs.target_ref }}
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/update-environment-image.yml
+++ b/.github/workflows/update-environment-image.yml
@@ -41,5 +41,6 @@ jobs:
     uses: ./.github/workflows/deploy-aws.yml
     with:
       environment: ${{ inputs.targetEnv }}
+      target_ref: ${{ needs.update-image.outputs.commit_sha }}
     secrets: inherit
       

--- a/scripts/update-env-image.sh
+++ b/scripts/update-env-image.sh
@@ -29,3 +29,7 @@ git config --global user.email "$gitEmail"
 git add $targetAppTaskPath $targetWorkerTaskPath
 git commit -m "release: Promote $sourceEnv image to $targetEnv"
 git push
+
+# Get the SHA of the commit
+commitSHA=$(git rev-parse HEAD)
+echo "COMMIT_SHA=${$commitSHA}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Ensures that `deploy-aws.yml` always uses the latest commit from the triggered branch when called via `update-env-image.yml`.

In #30, a change was made to eliminate the hardcoded `main` checkout in `deploy-aws.yml` in order to be able to deploy from a different branch (e.g., PR) to test changes to taskdefs, etc. Unfortunately, this caused an issue with the `update-env-image.yml` where it would result in the commit BEFORE the commit that is added in `update-env-image.yml` being deployed.

In short, when no `ref` is specified for `actions/checkout@v4`, it will use the SHA that triggered the workflow to run. In the case of `update-env-image.yml`, that SHA would be whatever is in the branch prior to running the workflow. However, the `update-env-image.yml` updates the prod taskdefs and commits so we need to ensure that `deploy-aws.yml` uses that commit and not the commit that triggered the workflow.

To resolve, `update-env-image.yml` passes in the `target_ref` that `deploy-aws.yaml` should use.  When `target-ref` input is not specified, the default works apply to resolving `ref` from `actions/checkout@v4` meaning whatever SHA triggered the workflow will be used.

This should provide the ability to deploy to prod as we have been but still be able to deploy from another branch to test taskdef changes.  Prior to #30, a manual deploy would always use the taskdef in `main` (since it was the hardcoded `ref` in deploy-aws.yml` so the only way to test a taskdef change was to merge to main first.