### PR TITLE
chore: run update image workflow as GitHub App for git purposes

### DIFF
--- a/.github/workflows/update-environment-image.yml
+++ b/.github/workflows/update-environment-image.yml
@@ -24,9 +24,20 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.sourceEnv }}
     steps:
+      - name: Create App Token for GitHub App
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          # In order to support running this workflow manually and still enforce rulesets, we need to run the git commands
+          # to update taskdefs as the GitHub App which is configured to bypass the rulesets.
+          # The "Update Image" GitHub App must be installed on the TheCloudMasters org and have permissions to write to the
+          # TheCloudMasters/uesio-infra repo.
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
       - name: Update Docker image
         env:
@@ -43,4 +54,3 @@ jobs:
       environment: ${{ inputs.targetEnv }}
       target_ref: ${{ needs.update-image.outputs.commit_sha }}
     secrets: inherit
-      


### PR DESCRIPTION
With the recent addition of rulesets on the repository to enforce everything coming through a PR, PR branches are updated to main before merge, approvals, etc. the ability to manually run the `Promote DEV Docker image to PROD` workflow was impacted because of the rules.

This PR updates the workflow to run as the GitHub App for git purposes in order to bypass the rules.