### PR TITLE
chore: force skip other workflows on update-env-image commit

### DIFF
--- a/scripts/update-env-image.sh
+++ b/scripts/update-env-image.sh
@@ -27,7 +27,13 @@ git config --global user.name "$gitUsername"
 git config --global user.email "$gitEmail"
 
 git add $targetAppTaskPath $targetWorkerTaskPath
-git commit -m "release: Promote $sourceEnv image to $targetEnv"
+# We're updating task definitions with a push from a GitHub App vs. GITHUB_TOKEN. Pushes made
+# by GITHUB_TOKEN do not trigger new workflows to prevent infinite loops. However, since we
+# are using the Github App Token to bypass rulesets, the push will trigger other workflows.
+# Since we are deploying to target environment in the next job of the workflow, we include
+# the [skip actions] tag to prevent the automatic deployment workflow from running on push to
+# main.
+git commit -m "release: Promote $sourceEnv image to $targetEnv [skip actions]"
 git push
 
 # Get the SHA of the commit


### PR DESCRIPTION
Add `[skip actions]` to commit message for `update-env-image` workflow.

We are committing the change to the image id as the GitHub App to bypass rulesets and be able to directly push to main. Previously, we used the GITHUB_TOKEN to do this and GH will not automatically trigger other `push` workflows when GITHUB_TOKEN is used to avoid infinite loops.

Now that we are commit as GitHub App, the other workflows will automatically trigger and since update-env-image contains a call to deploy after the commit, we do not want the automatic env deploy workflow to run. 

Specifying `[skip actions]` will ensure other `push` workflow triggers are skipped.